### PR TITLE
performance(sqlcipher): Fix burn_stack performance issue

### DIFF
--- a/burn_stack.c
+++ b/burn_stack.c
@@ -21,10 +21,8 @@
 */
 void burn_stack(unsigned long len)
 {
-   unsigned char buf[32];
+   unsigned char buf[len];
    zeromem(buf, sizeof(buf));
-   if (len > (unsigned long)sizeof(buf))
-      burn_stack(len - sizeof(buf));
 }
 
 

--- a/zeromem.c
+++ b/zeromem.c
@@ -9,11 +9,21 @@
  * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
  */
 #include "tomcrypt.h"
+#include <string.h>
 
 /**
    @file zeromem.c
    Zero a block of memory, Tom St Denis
 */
+
+/*
+ * Pointer to memset is volatile so that compiler must de-reference
+ * the pointer and can't assume that it points to any function in
+ * particular (such as memset, which it then might further "optimize")
+ */
+typedef void *(*memset_t)(void *, int, size_t);
+
+static volatile memset_t memset_func = memset;
 
 /**
    Zero a block of memory
@@ -22,11 +32,8 @@
 */
 void zeromem(void *out, size_t outlen)
 {
-   unsigned char *mem = out;
    LTC_ARGCHKVD(out != NULL);
-   while (outlen-- > 0) {
-      *mem++ = 0;
-   }
+   memset_func((void *)out, 0, outlen);
 }
 
 /* $Source$ */


### PR DESCRIPTION
Fixing status-im/status-desktop#10572

Implements a cross-platform version of OP-TEE/optee_os#3102

1. Remove recursion
2. Use memset instead of while loop

zeromem weights about 50% of the total CPU time on M1 Macs and seems to be major performance offender. It is used to clear the stack when using variables with sensitive information.