### PR TITLE
Fix android builds of statusgo for ndk r26b

### DIFF
--- a/aesce.c
+++ b/aesce.c
@@ -101,6 +101,7 @@ int mbedtls_aesce_has_support(void)
 #endif
 }
 
+__attribute__((target("aes,crypto")))
 static uint8x16_t aesce_encrypt_block(uint8x16_t block,
                                       unsigned char *keys,
                                       int rounds)
@@ -125,6 +126,7 @@ static uint8x16_t aesce_encrypt_block(uint8x16_t block,
     return block;
 }
 
+__attribute__((target("aes,crypto")))
 static uint8x16_t aesce_decrypt_block(uint8x16_t block,
                                       unsigned char *keys,
                                       int rounds)
@@ -182,10 +184,12 @@ int mbedtls_aesce_crypt_ecb(mbedtls_aes_context *ctx,
 /*
  * Compute decryption round keys from encryption round keys
  */
+__attribute__((target("aes,crypto")))
 void mbedtls_aesce_inverse_key(unsigned char *invkey,
                                const unsigned char *fwdkey,
                                int nr)
 {
+
     int i, j;
     j = nr;
     vst1q_u8(invkey, vld1q_u8(fwdkey + j * 16));
@@ -202,6 +206,7 @@ static inline uint32_t aes_rot_word(uint32_t word)
     return (word << (32 - 8)) | (word >> 8);
 }
 
+__attribute__((target("aes,crypto")))
 static inline uint32_t aes_sub_word(uint32_t in)
 {
     uint8x16_t v = vreinterpretq_u8_u32(vdupq_n_u32(in));


### PR DESCRIPTION
## Summary

This PR fixes a build error which was generated after we upgraded our Android NDK from `25.2.9519653` to `26.1.10909125`

```
Building status-go for: android/arm,android/arm64,android/386
/nix/store/c9v1brjfqvk8pag8gglwgk7whv5z8ng5-gomobile-unstable-2022-05-18/bin/gomobile: 
go build -tags gowaku_skip_migrations,gowaku_no_rln -ldflags -X github.com/status-im/status-
go/params.GitCommit=b866640dc56471846f530e907d50a1df6df13ae0 -X 
github.com/status-im/status-go/params.IpfsGatewayURL=https://ipfs.status.im/ -X
 github.com/status-im/status-go/params.Version=0.186.0 -s -w -buildid= -buildmode=c-shared 
 -o=/private/tmp/nix-build-status-go-0.186.0-b866640-android.drv-0/gomobile-work/android/src/main/
 jniLibs/arm64-v8a/libgojni.so ./gobind failed: exit status 1

# github.com/status-im/status-go/vendor/github.com/mutecomm/go-sqlcipher/v4
aesce.c:194:18: error: always_inline function 'vaesimcq_u8' requires target feature 'aes', 
but would be inlined into function 'mbedtls_aesce_inverse_key' that is compiled without support for 'aes'
```

The following functions need to be compiled with target for both as `aes` and `crypto` :
- `aesce_encrypt_block`
- `aesce_decrypt_block`
- `aes_sub_word`
- `mbedtls_aesce_inverse_key`

related status-go PR : https://github.com/status-im/status-go/pull/5844

